### PR TITLE
Fix contrast of text alert, fix FOUS, format top intro text nicer

### DIFF
--- a/src/_includes/templates/top-hero-text.vto
+++ b/src/_includes/templates/top-hero-text.vto
@@ -7,7 +7,7 @@
         {{ hero.title }}
         </h1>
       </div> 
-      <p class="text-base font-medium text-accent-500 lg:col-span-2 text-pretty">  
+      <p class="prose prose-stone text-accent-500 lg:col-span-2 text-pretty">  
       {{ hero.copy }}
       </p> 
     </div>  

--- a/src/_includes/templates/top-infoalert.vto
+++ b/src/_includes/templates/top-infoalert.vto
@@ -12,10 +12,10 @@
     {{ alert.update }} 
     {{ if lang === "ja" }}
       {{ webinfolast.map(item => item['DateJP']) }}:</span>
-      {{ webinfolast.map(item => item['記事']) }}
+      <span class="text-accent-900 font-base">{{ webinfolast.map(item => item['記事']) }}</span>
     {{ else }}
       {{ webinfolast.map(item => item['Date']) }}:</span>
-      {{ webinfolast.map(item => item['Description']) }}
+      <span class="text-accent-900 font-base">{{ webinfolast.map(item => item['Description']) }}</span>
     {{ /if }}
   </span>
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -128,7 +128,7 @@
   --breakpoint-3xl: 108rem;
   --breakpoint-4xl: 120rem;
   --breakpoint-5xl: 160rem;
-  --default-font-feature-settings: "kern" 1, "liga" 1, "clig" 1, "calt" 1, "palt" 0, "zero" 1, "sups" 0, "frac" 0, "ordn" 0, "smcp" 1, "onum" 0, "tnum" 0, "swsh" 0, "ss01" 0, "ss02" 0, "ss03" 0, "ss04" 0, "ss05" 0, "ss06" 0, "ss07" 0, "ss08" 0, "ss09" 0;
+  --default-font-feature-settings: "kern" 1, "liga" 1, "clig" 1, "calt" 1, "palt" 0, "zero" 1, "sups" 0, "frac" 0, "ordn" 0, "smcp" 0, "onum" 0, "tnum" 0, "swsh" 0, "ss01" 0, "ss02" 0, "ss03" 0, "ss04" 0, "ss05" 0, "ss06" 0, "ss07" 0, "ss08" 0, "ss09" 0;
   --default-font-variant-ligatures: common-ligatures;
   --header-top: 1rem;
   --font-sans: textface, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";


### PR DESCRIPTION
a1db367046123ed6748da9ffe3ea7da9f28f9487
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 06:01:45 2025 +0900

### Fix contrast of alert text color
Text was defaulting to a dark grey but on some mobile browsers it went white. Specify it so it stays dark for better contrast.

Fixes: #4



cf4bf0966fb7dc377f370f03b153634cfa3261a9
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 05:59:40 2025 +0900

### Set initial copy to use prose
Top copy looked too heavy set in medium so set it to use prose instead.



97a6b51f0fbe1d667758693842bae04d8e0d69b9
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 05:58:42 2025 +0900

### Remove small caps from default
Small caps in the default causes FOUS, where all the text flashes as small text before reverting. Better to style it using arbitrary style where needed like:

`font-light [font-variant:small-caps]`



