### PR TITLE
Remove fixed width from big logo svg and adjust in css

### DIFF
--- a/src/_includes/templates/top-biglogo.vto
+++ b/src/_includes/templates/top-biglogo.vto
@@ -12,7 +12,7 @@
     alt="#_" 
     loading="lazy" 
     decoding="async" 
-    class="fill-accent-100 absolute origin-bottom-left scale-75 2xs:scale-87 1xs:scale-102 xs:scale-110 sm:scale-150 md:scale-183 lg:scale-230 xl:scale-285 1xl:scale-321 2xl:scale-343 2xlb:scale-357 3xl:scale-375 4xl:scale-375 -bottom-6 2xs:-bottom-7 1xs:-bottom-8 xs:-bottom-9 sm:-bottom-12 md:-bottom-15 lg:-bottom-19 xl:-bottom-23 1xl:-bottom-27 2xl:-bottom-29 2xlb:-bottom-30 3xl:-bottom-32 4xl:-bottom-32 -left-5 sm:-left-10 md:-left-15 lg:-left-23" 
+    class="fill-accent-100 absolute origin-bottom-left w-114 scale-75 2xs:scale-87 1xs:scale-102 xs:scale-110 sm:scale-150 md:scale-183 lg:scale-230 xl:scale-285 1xl:scale-321 2xl:scale-343 2xlb:scale-357 3xl:scale-372 4xl:scale-375 -bottom-6 2xs:-bottom-7 1xs:-bottom-8 xs:-bottom-9 sm:-bottom-12 md:-bottom-15 lg:-bottom-19 xl:-bottom-23 1xl:-bottom-27 2xl:-bottom-29 2xlb:-bottom-30 3xl:-bottom-32 4xl:-bottom-32 -left-5 sm:-left-10 md:-left-15 lg:-left-23" 
   inline>
 </section>
 <!-- ===== top-biglogo.vto TEMPLATE END ===== -->

--- a/src/assets/logo_horiz_nocolor_bgtransparent.svg
+++ b/src/assets/logo_horiz_nocolor_bgtransparent.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="454px" height="111px" viewBox="0 0 454 111" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 454 111" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>logo_horiz_grey_bgtransparent</title>
     <defs>
         <polygon id="path-1" points="0 0 80.7099981 0 80.7099981 109.483298 0 109.483298"></polygon>


### PR DESCRIPTION
4e6904bb7fe6316ce08b634e31938f172b83e86f
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 15:15:43 2025 +0900

### Remove fixed width from big logo svg and adjust in css
Having a fixed width in the svg sometimes causes trouble, so better to remove the fixed value and set it with css outside the svg.




