### PR TITLE
Enable pagefind section search for top page

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -101,9 +101,13 @@ site.use(multilanguage({
 }));
 site.use(nav());
 site.use(pagefind({
-  element: "#search",
-  resetStyles: false,
-  showSubResults: true,
+  ui: {
+    containerId: "search",
+    showImages: false,
+    showEmptyFilters: true,
+    resetStyles: false,
+    showSubResults: true,
+  },
 }));
 site.use(prism({
   theme: [

--- a/_config.ts
+++ b/_config.ts
@@ -103,6 +103,7 @@ site.use(nav());
 site.use(pagefind({
   element: "#search",
   resetStyles: false,
+  showSubResults: true,
 }));
 site.use(prism({
   theme: [

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "lume/": "https://deno.land/x/lume@v3.0.1/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
-    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.9/jsx-runtime.ts"
+    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.10/jsx-runtime.ts"
   },
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",

--- a/src/_components/top_section.vto
+++ b/src/_components/top_section.vto
@@ -1,7 +1,7 @@
 {{# Use: 
-{{ comp.top-section({ tag: "h2", text: services.section }) }}
-{{ comp.top-section({ tag: "h2", text: somevar }) }}
-{{ comp.top-section({ tag: "h2", bg: "dark", text: testimonials.section, cssclass: "max-w-xl" }) }}
+{{ comp.top_section({ tag: "h2", text: services.section, id: "services" }) }}
+{{ comp.top_section({ tag: "h2", text: somevar, id: "someid" }) }}
+{{ comp.top_section({ tag: "h2", bg: "dark", text: testimonials.section, id: "testimonials", cssclass: "max-w-xl" }) }}
 #}}
 
 {{ if bg === "dark" }}
@@ -15,7 +15,7 @@
     </div>
   </div>
   <div class="relative flex justify-left md:justify-center">
-    <{{ tag }} class="bg-yellow-500 rounded pl-0 pr-2 md:pl-2 text-xl sm:text-xl md:text-2xl lg:text-3xl tracking-wider text-white font-light [font-variant:small-caps]">{{ text }}</{{ tag }}>
+    <{{ tag }} id="{{ id }}" class="bg-yellow-500 rounded pl-0 pr-2 md:pl-2 text-xl sm:text-xl md:text-2xl lg:text-3xl tracking-wider text-white font-light [font-variant:small-caps]"><a class="hover:text-sky-500" href="#{{ id }}">{{ text }}</a></{{ tag }}>
   </div>
 </div>
 {{ else }}
@@ -29,7 +29,7 @@
     </div>
   </div>
   <div class="relative flex justify-left md:justify-center">
-    <{{ tag }} class="bg-white pl-0 pr-2 md:pl-2 text-xl sm:text-xl md:text-2xl lg:text-3xl tracking-wider text-yellow-500 font-light [font-variant:small-caps]">{{ text }}</{{ tag }}>
+    <{{ tag }} id="{{ id }}" class="bg-white pl-0 pr-2 md:pl-2 text-xl sm:text-xl md:text-2xl lg:text-3xl tracking-wider text-yellow-500 font-light [font-variant:small-caps]"><a class="text-yellow-500 hover:text-sky-500" href="#{{ id }}">{{ text }}</a></{{ tag }}>
   </div>
 </div>
 {{ /if }}

--- a/src/_includes/templates/top-certs.vto
+++ b/src/_includes/templates/top-certs.vto
@@ -3,9 +3,12 @@
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl pt-8 pb-8">  
     <div class="grid grid-cols-1 gap-12 items-center lg:grid-cols-4 md:grid-cols-2"> 
       <div class="col-span-full lg:col-span-1 lg:max-w-none lg:mr-auto mx-auto"> 
-        <h3 class="prose prose-zinc text-sm text-balance">  
+        <h2 id="certifications" class="prose prose-zinc font-semibold text-sm text-balance">  
+          <a class="text-yellow-500 hover:text-sky-500 no-underline" href="#certifications">{{ certifications.title }}</a>
+        </h2> 
+        <p class="prose prose-zinc text-sm text-balance">
           {{ certifications.copy }}
-        </h3> 
+        </p> 
       </div> 
       <div class="md:col-span-3"> 
         <div class="flex flex-wrap justify-around items-center gap-1">

--- a/src/_includes/templates/top-hireus.vto
+++ b/src/_includes/templates/top-hireus.vto
@@ -3,7 +3,7 @@
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl py-12">  
     <div class="flex flex-col flex-shrink-0 gap-8 md:flex-row md:gap-12 md:items-end no-external-icon"> 
       <div> 
-        {{ comp.top_section({ tag: "h2", bg: "dark", text: hireus.section, cssclass: "max-w-xs" }) }}
+        {{ comp.top_section({ tag: "h2", bg: "dark", text: hireus.section, id: "hireus", cssclass: "max-w-xs" }) }}
         {{ comp.top_title({ tag: "h3", bg: "dark", text: hireus.title }) }}
         {{ comp.top_subtitle({ tag: "p", bg: "dark", text: hireus.subtitle }) }}
         <div class="mt-6 border-t border-accent-400">

--- a/src/_includes/templates/top-partners.vto
+++ b/src/_includes/templates/top-partners.vto
@@ -3,9 +3,12 @@
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl py-12">  
     <div class="grid grid-cols-1 gap-12 items-center lg:grid-cols-4 md:grid-cols-2"> 
       <div class="col-span-full lg:col-span-1 lg:max-w-none lg:mr-auto mx-auto"> 
-        <h3 class="prose prose-zinc text-sm text-balance">  
+        <h2 id="partners" class="prose prose-zinc font-semibold text-sm text-balance">  
+          <a class="text-yellow-500 hover:text-sky-500 no-underline" href="#partners">{{ partners.title }}</a>
+        </h2> 
+        <p class="prose prose-zinc text-sm text-balance">
           {{ partners.copy }}
-        </h3> 
+        </p>
       </div> 
       <div class="md:col-span-3"> 
         <div class="flex flex-wrap justify-around items-center gap-1">

--- a/src/_includes/templates/top-projects.vto
+++ b/src/_includes/templates/top-projects.vto
@@ -2,7 +2,7 @@
 <section class="bg-white overflow-hidden relative py-20 sm:py-20">
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl">
     <div class="mx-auto max-w-2xl text-left md:text-center">
-      {{ comp.top_section({ tag: "h2", text: recentprojects.section }) }}
+      {{ comp.top_section({ tag: "h2", text: recentprojects.section, id: "projects" }) }}
       {{ comp.top_title({ tag: "h3", text: recentprojects.title }) }}
       {{ comp.top_subtitle({ tag: "p", text: recentprojects.subtitle }) }}
       <div class="mt-6 flex items-center justify-start md:justify-center">

--- a/src/_includes/templates/top-services.vto
+++ b/src/_includes/templates/top-services.vto
@@ -2,7 +2,7 @@
 <section class="bg-white overflow-hidden relative"> 
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl py-24">  
     <div class="w-full max-w-xl"> 
-      {{ comp.top_section({ tag: "h2", text: services.section }) }}
+      {{ comp.top_section({ tag: "h2", text: services.section, id: "services" }) }}
       {{ comp.top_title({ tag: "h3", text: services.title }) }}
       {{ comp.top_subtitle({ tag: "p", text: services.subtitle }) }}
     </div> 

--- a/src/_includes/templates/top-testimonials.vto
+++ b/src/_includes/templates/top-testimonials.vto
@@ -3,7 +3,7 @@
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl py-16">  
     <div class="grid lg:grid-cols-2 gap-12 items-start"> 
       <div> 
-        {{ comp.top_section({ tag: "h2", text: testimonials.section }) }}
+        {{ comp.top_section({ tag: "h2", text: testimonials.section, id: "testimonials" }) }}
         {{ comp.top_title({ tag: "h3", text: testimonials.title }) }}
         {{ comp.top_subtitle({ tag: "p", text: testimonials.subtitle }) }}
       </div> 

--- a/src/_includes/templates/top-trackrecord.vto
+++ b/src/_includes/templates/top-trackrecord.vto
@@ -11,7 +11,7 @@
   <div class="mx-auto grid max-w-7xl lg:grid-cols-2">
     <div class="px-6 pt-16 pb-24 sm:pt-20 sm:pb-32 lg:col-start-2 lg:px-8 lg:pt-32">
       <div class="mx-auto max-w-2xl lg:mr-0 lg:max-w-lg">
-        {{ comp.top_section({ tag: "h2", text: trackrecord.section }) }}
+        {{ comp.top_section({ tag: "h2", text: trackrecord.section, id: "trackrecord" }) }}
         {{ comp.top_title({ tag: "h3", text: trackrecord.title }) }}
         {{ comp.top_subtitle({ tag: "p", text: trackrecord.subtitle }) }}
         <dl class="mt-16 grid max-w-xl grid-cols-1 gap-8 sm:mt-20 sm:grid-cols-2 xl:mt-16">

--- a/src/_includes/templates/top-why.vto
+++ b/src/_includes/templates/top-why.vto
@@ -16,7 +16,7 @@
 
     <div class="px-8 py-12 mx-auto max-w-8xl md:px-16"> 
       <div class="flex flex-col max-w-2xl lg:ml-auto"> 
-        {{ comp.top_section({ tag: "h2", bg: "dark", text: whyesolia.section, cssclass: "max-w-xl" }) }}
+        {{ comp.top_section({ tag: "h2", bg: "dark", text: whyesolia.section, id: "whyesolia", cssclass: "max-w-xl" }) }}
         {{ comp.top_title({ tag: "h3", bg: "dark", text: whyesolia.title }) }}
         {{ comp.top_subtitle({ tag: "p", bg: "dark", text: whyesolia.subtitle }) }}
       </div> 


### PR DESCRIPTION
fe4752a53e771fc6627e3abe67f4cbcb748d25c5
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 15:40:54 2025 +0900

### Enable section search 2
Debugged pagefind, and it needed a different config object. I had the old one. Switched to be a child of ui, and added the setting to showSubResults.

Added id's and anchor tags to each section on the landing, so that they now appear in search.

Refactored certs and partners, so that they too have an h2 (formatted small) and can also appear in search.



011aec15ffd69bb0bec2db35d33f09d534528822
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 10:38:38 2025 +0900

### Enable section search 1
Pagefind has an option to search sub sections on a page, as long as they have an id and anchor. Enable it so we can try. (way of enabling was mistaken!)



d563c2a84dff03b7542ab8ed673747233aa0540e
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 10:37:52 2025 +0900

### Update Lume
CLI lume update just resulted in jsx runtime being updated...



