### PR TITLE
Refactors styles and improves content presentation

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -14,6 +14,7 @@ import metas from "lume/plugins/metas.ts";
 import multilanguage from "lume/plugins/multilanguage.ts";
 import nav from "lume/plugins/nav.ts";
 import pagefind from "lume/plugins/pagefind.ts";
+import plaintext from "lume/plugins/plaintext.ts";
 import prism from "lume/plugins/prism.ts";
 import "npm:prismjs@1.29.0/components/prism-git.js";
 import "npm:prismjs@1.29.0/components/prism-json.js";
@@ -109,6 +110,7 @@ site.use(pagefind({
     showSubResults: true,
   },
 }));
+site.use(plaintext());
 site.use(prism({
   theme: [
     {

--- a/src/_components/top_subtitle.vto
+++ b/src/_components/top_subtitle.vto
@@ -5,11 +5,11 @@
 #}}
 
 {{ if bg === "dark" }}
-<{{ tag }} class="prose prose-zinc text-white prose-base sm:prose-md md:prose-xl mt-6 md:mt-8 text-balance">  
+<{{ tag }} class="prose prose-neutral text-white prose-base sm:prose-md md:prose-xl mt-6 md:mt-8 text-balance">  
   {{ text |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
 </{{ tag }}>
 {{ else }}
-<{{ tag }} class="prose prose-zinc prose-base prose-p:text-accent-900 sm:prose-md md:prose-xl mt-6 md:mt-8 text-balance">  
+<{{ tag }} class="prose prose-neutral prose-base prose-p:text-accent-900 sm:prose-md md:prose-xl mt-6 md:mt-8 text-balance">  
   {{ text |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}  
 </{{ tag }}>
 {{ /if }}

--- a/src/_data.yml
+++ b/src/_data.yml
@@ -24,8 +24,8 @@ footernav:
       aria_label: サイト内リンク
       title: サイトマップへのリンク
     - text: プライバシーポリシー
-      href: https://esolia.co.jp/privacy
-      target: _blank
+      href: /privacy
+      target: _self
       icon: privacy
       aria_label: サイト内リンク
       title: プライバシーポリシーへのリンク
@@ -100,8 +100,8 @@ en:
         aria_label: Site internal link
         title: Link to the Sitemap
       - text: Privacy Policy
-        href: https://esolia.com/privacy
-        target: _blank
+        href: /en/privacy
+        target: _self
         icon: privacy
         aria_label: Site internal link
         title: Link to the Privacy Policy

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -11,7 +11,7 @@ script: /js/fathom-post-list-event.js
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
             <h1
-              class="text-4xl font-bold tracking-tight text-stone-800 sm:text-5xl dark:text-stone-100"
+              class="text-4xl font-bold tracking-tight text-accent-800 sm:text-5xl dark:text-accent-100"
             >
               <span class="font-light subpixel-antialiased">{{ site.title }}</span>
               <br class="block sm:hidden">
@@ -19,7 +19,7 @@ script: /js/fathom-post-list-event.js
                 class="bg-gradient-to-r from-esoliablue-800 via-esoliablue-700 to-esoliablue-900 dark:from-esoliablue-600 dark:via-esoliablue-500 dark:to-esoliablue-700 bg-clip-text text-transparent"
               >{{ i18n.archive.title }}</span>
             </h1>
-            <p class="mt-6 text-base text-stone-600 dark:text-stone-400">
+            <p class="mt-6 text-base text-accent-600 dark:text-accent-400">
               {{ i18n.archive.description }}
             </p>
 
@@ -41,7 +41,7 @@ script: /js/fathom-post-list-event.js
                 )
               }}
               {{ if pageCats.length }}
-                <div class="text-stone-500 ml-1 mt-6">
+                <div class="text-accent-500 ml-1 mt-6">
                   <nav class="">
                     <h2>{{ i18n.search.categories }}:</h2>
                     <ul class="flex flex-wrap space-x-2 space-y-2">
@@ -60,7 +60,7 @@ script: /js/fathom-post-list-event.js
 
               {{ set pageTags = search.pages(`type=tag lang=${lang}`, "tag") }}
               {{ if pageTags.length }}
-                <div class="text-stone-500 ml-1 mt-4">
+                <div class="text-accent-500 ml-1 mt-4">
                   <nav class="">
                     <h2>{{ i18n.search.tags }}:</h2>
                     <ul class="flex flex-wrap space-x-2 space-y-2">
@@ -68,7 +68,7 @@ script: /js/fathom-post-list-event.js
                         <li>
                           <a
                             href="{{ page.url }}"
-                            class="rounded-md bg-stone-50 dark:bg-stone-700 px-2 py-1 text-xs font-medium text-stone-600 dark:text-stone-50 ring-1 ring-stone-500/10 ring-inset hover:bg-stone-100 dark:hover:bg-stone-500 no-underline whitespace-nowrap"
+                            class="rounded-md bg-stone-50 dark:bg-stone-700 px-2 py-1 text-xs font-medium text-accent-600 dark:text-accent-50 ring-1 ring-stone-500/10 ring-inset hover:bg-stone-100 dark:hover:bg-stone-500 no-underline whitespace-nowrap"
                           >{{ page.tag }}</a>
                         </li>
                       {{ /for }}

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -11,7 +11,7 @@ script: /js/fathom-post-list-event.js
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
             <h1
-              class="text-4xl font-bold tracking-tight text-accent-800 sm:text-5xl dark:text-accent-100"
+              class="text-4xl font-bold tracking-tight text-accent-900 sm:text-5xl dark:text-accent-100"
             >
               <span class="font-light subpixel-antialiased">{{ site.title }}</span>
               <br class="block sm:hidden">

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -11,11 +11,11 @@ bodyClass: body-tag
           <header class="max-w-2xl space-y-10">
             <div class=""><a href="/archive/">{{ i18n.nav.back }}</a></div>
             <h1
-              class="text-4xl font-thin tracking-tight text-accent-800 sm:text-5xl dark:text-accent-100 subpixel-antialiased"
+              class="text-4xl font-thin tracking-tight text-accent-900 sm:text-5xl dark:text-accent-100 subpixel-antialiased"
             >
               {{ title }}
             </h1>
-            <p class="text-accent-800 dark:text-accent-200">{{ summary }}</p>
+            <p class="text-accent-900 dark:text-accent-200">{{ summary }}</p>
             {{
               include "templates/post-list.vto" { postslist: search.pages(search_query) }
             }}

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -11,11 +11,11 @@ bodyClass: body-tag
           <header class="max-w-2xl space-y-10">
             <div class=""><a href="/archive/">{{ i18n.nav.back }}</a></div>
             <h1
-              class="text-4xl font-thin tracking-tight text-stone-800 sm:text-5xl dark:text-stone-100 subpixel-antialiased"
+              class="text-4xl font-thin tracking-tight text-accent-800 sm:text-5xl dark:text-accent-100 subpixel-antialiased"
             >
               {{ title }}
             </h1>
-            <p class="text-stone-800 dark:text-stone-200">{{ summary }}</p>
+            <p class="text-accent-800 dark:text-accent-200">{{ summary }}</p>
             {{
               include "templates/post-list.vto" { postslist: search.pages(search_query) }
             }}

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ it.title || metas.title }} - {{ site.title }}</title>
+    <title>{{ title |> plaintext }} - {{ site.title }}</title>
     <meta name="supported-color-schemes" content="light dark">
     <meta
       name="theme-color"

--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -9,12 +9,12 @@ bodyClass: body-tag
     <div class="2xl:max-w-7xl mx-auto px-8 md:px-16 max-w-6xl py-12 lg:pt-24">  
       <div class="flex flex-col gap-4 lg:grid-cols-3"> 
         <div class="max-w-xl"> 
-          <h1 class="text-3xl  sm:text-3xl md:text-4xl lg:text-5xl tracking-tighter font-display text-accent-800 text-balance">  {{ title }}  </h1> 
+          <h1 class="text-3xl  sm:text-3xl md:text-4xl lg:text-5xl tracking-tighter font-display text-accent-900 text-balance">  {{ title }}  </h1> 
           {{# <p class="text-lg sm:text-xl md:text-2xl text-accent-500 mt-8 font-display text-balance">  {{ date }}  </p>  #}}
 
           {{ if toc.length }}{{ include "templates/page-toc.vto" }}{{ /if }}
 
-          <div class="prose prose-zinc prose-a:font-semibold prose-a:text-sky-900 hover:prose-a:text-sky-800 prose-headings:text-accent-900 prose-headings:font-display   prose-blockquote:text-accent-400 prose-code:text-accent-400 prose-strong:text-accent-700 prose-img:rounded-xl prose-pre:rounded-xl prose-pre:scrollbar-hide mt-12">
+          <div class="prose prose-neutral prose-a:font-semibold prose-a:text-sky-900 hover:prose-a:text-sky-800 prose-headings:text-accent-900 prose-headings:font-display   prose-blockquote:text-accent-400 prose-code:text-accent-400 prose-strong:text-accent-700 prose-img:rounded-xl prose-pre:rounded-xl prose-pre:scrollbar-hide mt-12">
             {{ content }}
           </div>
         </div>

--- a/src/_includes/layouts/page1.vto
+++ b/src/_includes/layouts/page1.vto
@@ -27,7 +27,7 @@ bodyClass: body-tag
                       <ul class="list-disc list-inside space-y-2 text-sm font-light">
                         {{ for item of toc }}
                         <li class="font-light">
-                          <a class="text-stone-500 hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
+                          <a class="text-accent-500 hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
                           {{ if item.children.length }}
                           <ul>
                             {{ for child of item.children }}

--- a/src/_includes/layouts/page1.vto
+++ b/src/_includes/layouts/page1.vto
@@ -44,7 +44,7 @@ bodyClass: body-tag
                   {{ /if }} #}}
                 </header>
                 <div
-                  class="prose max-w-[70ch] prose-zinc sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
+                  class="prose max-w-[70ch] prose-neutral sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
                   data-mdx-content="true"
                 >
                 {{ content }}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -17,7 +17,7 @@ bodyClass: body-post
                 <header class="flex flex-col -top-4">
                   {{ include "templates/post-details.vto" { elapsed: elapseddays } }}
                   <h1
-                    class="mt-6 text-3xl font-bold tracking-tight text-stone-800 sm:text-4xl dark:text-stone-100 subpixel-antialiased"
+                    class="mt-6 text-3xl font-bold tracking-tight text-accent-800 sm:text-4xl dark:text-accent-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -17,7 +17,7 @@ bodyClass: body-post
                 <header class="flex flex-col -top-4">
                   {{ include "templates/post-details.vto" { elapsed: elapseddays } }}
                   <h1
-                    class="mt-6 text-3xl font-bold tracking-tight text-accent-800 sm:text-4xl dark:text-accent-100 subpixel-antialiased"
+                    class="mt-6 text-3xl font-bold tracking-tight text-accent-900 sm:text-4xl dark:text-accent-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>
@@ -26,7 +26,7 @@ bodyClass: body-post
 
                 </header>
                 <div
-                  class="prose max-w-[70ch] prose-zinc sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
+                  class="prose max-w-[70ch] prose-neutral sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
                   data-mdx-content="true"
                 >
                 {{ content }}

--- a/src/_includes/templates/featured1.vto
+++ b/src/_includes/templates/featured1.vto
@@ -16,17 +16,17 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">Blog Post Title</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-stone-900 dark:text-stone-100 whitespace-normal"
+          class="w-full flex-none text-sm font-medium text-accent-900 dark:text-accent-100 whitespace-normal"
         >
           Featured post title number 1
         </dd>
         <dt class="sr-only">Role</dt>
-        <dd class="text-xs text-stone-500 dark:text-stone-400">
+        <dd class="text-xs text-accent-500 dark:text-accent-400">
           Short explanation of the category
         </dd>
         {{# <dt class="sr-only">Date</dt>
         <dd
-          class="ml-auto text-xs text-stone-400 dark:text-stone-500"
+          class="ml-auto text-xs text-accent-400 dark:text-accent-500"
           aria-label="2019 until Present"
         >
           <time datetime="2019">2019</time>
@@ -51,12 +51,12 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">Blog Post Title</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-stone-900 dark:text-stone-100 whitespace-normal"
+          class="w-full flex-none text-sm font-medium text-accent-900 dark:text-accent-100 whitespace-normal"
         >
           Featured post title number 2
         </dd>
         <dt class="sr-only">Role</dt>
-        <dd class="text-xs text-stone-500 dark:text-stone-400">
+        <dd class="text-xs text-accent-500 dark:text-accent-400">
           Short explanation of the category
         </dd>
       </dl>
@@ -77,12 +77,12 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">Blog Post Title</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-stone-900 dark:text-stone-100 whitespace-normal"
+          class="w-full flex-none text-sm font-medium text-accent-900 dark:text-accent-100 whitespace-normal"
         >
           Featured post title number 3
         </dd>
         <dt class="sr-only">Role</dt>
-        <dd class="text-xs text-stone-500 dark:text-stone-400">
+        <dd class="text-xs text-accent-500 dark:text-accent-400">
           Short explanation of the category
         </dd>
       </dl>

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -83,10 +83,10 @@
             inline
           ></a>
       </div>
-      <p class="mt-6 text-sm text-stone-200 sm:mt-0 text-center sm:text-left">
+      <p class="mt-6 text-sm text-accent-200 sm:mt-0 text-center sm:text-left">
         ©{{ new Date().getFullYear() }}
         {{ i18n.home.company_long }} All rights reserved.<br>
-        <span class="text-xs text-stone-100">{{
+        <span class="text-xs text-accent-100">{{
           i18n.home.company_address
         }}</span>
       </p>

--- a/src/_includes/templates/footer2.vto
+++ b/src/_includes/templates/footer2.vto
@@ -8,7 +8,7 @@
               class="flex flex-col items-center justify-between gap-6 md:flex-row"
             >
               <div
-                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-accent-800 dark:text-accent-200"
+                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-accent-900 dark:text-accent-200"
               >
                 {{- for item of it.footernav.links }}
                   <a

--- a/src/_includes/templates/footer2.vto
+++ b/src/_includes/templates/footer2.vto
@@ -8,7 +8,7 @@
               class="flex flex-col items-center justify-between gap-6 md:flex-row"
             >
               <div
-                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-stone-800 dark:text-stone-200"
+                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-accent-800 dark:text-accent-200"
               >
                 {{- for item of it.footernav.links }}
                   <a
@@ -21,7 +21,7 @@
                     <span class="sr-only">({{ item.aria_label }})</span></a>
                 {{ /for -}}
               </div>
-              <p class="text-sm text-stone-400 dark:text-stone-500">
+              <p class="text-sm text-accent-400 dark:text-accent-500">
                 ©{{ new Date().getFullYear() }}
                 eSolia Inc. All rights reserved.
               </p>

--- a/src/_includes/templates/modal-mobilemenu.vto
+++ b/src/_includes/templates/modal-mobilemenu.vto
@@ -3,7 +3,7 @@
 {{# Modal Panel, hidden by default #}}
 <div id="mobile-menu-modal-panel" class="fixed top-0 right-0 bottom-0 w-64 bg-white z-[9999] overflow-y-auto p-4 hidden"> 
   {{# Modal Content Here #}}
-  <button id="mobile-menu-close-button" class="absolute top-2 right-2 text-accent-600 hover:text-accent-800"> 
+  <button id="mobile-menu-close-button" class="absolute top-2 right-2 text-accent-600 hover:text-accent-900"> 
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
     </svg>
@@ -25,7 +25,7 @@
       <li>
         <a 
           href="{{ item.href }}" 
-          class="text-accent-800 hover:text-sky-600 {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
+          class="text-accent-900 hover:text-sky-600 {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
           {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
           role="menuitem"
           aria-label="{{ item.aria_label }}"

--- a/src/_includes/templates/page-toc.vto
+++ b/src/_includes/templates/page-toc.vto
@@ -1,21 +1,25 @@
 <!-- ===== page-toc.vto TEMPLATE START ===== -->
-<nav class="max-w-2xl mt-4 mr-auto bg-white prose dark:prose-invert dark:bg-stone-800 p-6 rounded-lg shadow-md ring-1 ring-accent-900/5">
-  <h2 class="mb-1 font-light">{{ i18n.nav.toc }}</h2>
-  <ul class="list-disc list-inside space-y-2 text-sm font-light">
-    {{ for item of toc }}
-    <li class="font-light">
-      <a class="text-stone-500 hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
-      {{ if item.children.length }}
-      <ul>
-        {{ for child of item.children }}
-        <li>
-          <a href="#{{ child.slug }}">{{ child.text }}</a>
-        </li>
-        {{ /for }}
-      </ul>
-      {{ /if }}
-    </li>
-    {{ /for }}
-  </ol>
+<nav class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-zinc prose-a:font-light prose-a:text-accent-900 prose-a:opacity-100 prose-a:hover:bg-white prose-a:transition prose-a:hover:text-sky-600 prose-a:hover:font-semibold dark:prose-a:text-accent-200 dark:prose-a:hover:text-esoliaamber-600 dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5">
+  <details id="toc-details" class="block" open>
+    <summary class="cursor-pointer md:cursor-default p-0">
+      <h2 class="text-base md:text-xl -mt-4 -mb-2 p-0 font-light inline-block">{{ i18n.nav.toc }}</h2>
+    </summary>
+    <ul class="list-disc list-inside space-y-2 text-sm">
+      {{ for item of toc }}
+      <li class="">
+        <a class="" href="#{{ item.slug }}">{{ item.text }}</a>
+        {{ if item.children.length }}
+        <ul>
+          {{ for child of item.children }}
+          <li>
+            <a class="" href="#{{ child.slug }}">{{ child.text }}</a>
+          </li>
+          {{ /for }}
+        </ul>
+        {{ /if }}
+      </li>
+      {{ /for }}
+    </ol>
+  </details>
 </nav>
 <!-- ===== page-toc.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/page-toc.vto
+++ b/src/_includes/templates/page-toc.vto
@@ -1,5 +1,5 @@
 <!-- ===== page-toc.vto TEMPLATE START ===== -->
-<nav class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-zinc prose-a:font-light prose-a:text-accent-900 prose-a:opacity-100 prose-a:hover:bg-white prose-a:transition prose-a:hover:text-sky-600 prose-a:hover:font-semibold dark:prose-a:text-accent-200 dark:prose-a:hover:text-esoliaamber-600 dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5">
+<nav class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-neutral prose-a:font-light prose-a:text-accent-900 prose-a:opacity-100 prose-a:hover:bg-white prose-a:transition prose-a:hover:text-sky-600 prose-a:hover:font-semibold dark:prose-a:text-accent-200 dark:prose-a:hover:text-esoliaamber-600 dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5">
   <details id="toc-details" class="block" open>
     <summary class="cursor-pointer md:cursor-default p-0">
       <h2 class="text-base md:text-xl -mt-4 -mb-2 p-0 font-light inline-block">{{ i18n.nav.toc }}</h2>

--- a/src/_includes/templates/panel-categories.vto
+++ b/src/_includes/templates/panel-categories.vto
@@ -1,6 +1,6 @@
 <!-- ===== panel-categories.vto TEMPLATE START ===== -->
 <div class="rounded-2xl border border-stone-100 p-6 dark:border-stone-700/40">
-  <h2 class="flex text-sm font-semibold text-stone-900 dark:text-stone-100">
+  <h2 class="flex text-sm font-semibold text-accent-900 dark:text-accent-100">
     <img
       alt=""
       loading="lazy"
@@ -28,17 +28,17 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-stone-900 dark:text-stone-100"
+          class="w-full flex-none text-sm font-medium text-accent-900 dark:text-accent-100"
         >
           Stories
         </dd>
         <dt class="sr-only">Role</dt>
-        <dd class="text-xs text-stone-500 dark:text-stone-400">
+        <dd class="text-xs text-accent-500 dark:text-accent-400">
           Short explanation of the category
         </dd>
         {{# <dt class="sr-only">Date</dt>
         <dd
-          class="ml-auto text-xs text-stone-400 dark:text-stone-500"
+          class="ml-auto text-xs text-accent-400 dark:text-accent-500"
           aria-label="2019 until Present"
         >
           <time datetime="2019">2019</time>
@@ -63,17 +63,17 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-stone-900 dark:text-stone-100"
+          class="w-full flex-none text-sm font-medium text-accent-900 dark:text-accent-100"
         >
           Tips
         </dd>
         <dt class="sr-only">Role</dt>
-        <dd class="text-xs text-stone-500 dark:text-stone-400">
+        <dd class="text-xs text-accent-500 dark:text-accent-400">
           Short explanation of the category
         </dd>
         {{# <dt class="sr-only">Date</dt>
         <dd
-          class="ml-auto text-xs text-stone-400 dark:text-stone-500"
+          class="ml-auto text-xs text-accent-400 dark:text-accent-500"
           aria-label="2019 until Present"
         >
           <time datetime="2019">2019</time>
@@ -98,17 +98,17 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-stone-900 dark:text-stone-100"
+          class="w-full flex-none text-sm font-medium text-accent-900 dark:text-accent-100"
         >
           Tutorials
         </dd>
         <dt class="sr-only">Role</dt>
-        <dd class="text-xs text-stone-500 dark:text-stone-400">
+        <dd class="text-xs text-accent-500 dark:text-accent-400">
           Short explanation of the category
         </dd>
         {{# <dt class="sr-only">Date</dt>
         <dd
-          class="ml-auto text-xs text-stone-400 dark:text-stone-500"
+          class="ml-auto text-xs text-accent-400 dark:text-accent-500"
           aria-label="2019 until Present"
         >
           <time datetime="2019">2019</time>
@@ -133,17 +133,17 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-stone-900 dark:text-stone-100"
+          class="w-full flex-none text-sm font-medium text-accent-900 dark:text-accent-100"
         >
           Announcements
         </dd>
         <dt class="sr-only">Role</dt>
-        <dd class="text-xs text-stone-500 dark:text-stone-400">
+        <dd class="text-xs text-accent-500 dark:text-accent-400">
           Short explanation of the category
         </dd>
         {{# <dt class="sr-only">Date</dt>
         <dd
-          class="ml-auto text-xs text-stone-400 dark:text-stone-500"
+          class="ml-auto text-xs text-accent-400 dark:text-accent-500"
           aria-label="2019 until Present"
         >
           <time datetime="2019">2019</time>
@@ -154,7 +154,7 @@
     </li>
   </ol>
   <a
-    class="group mt-6 inline-flex w-full items-center justify-center gap-2 rounded-md bg-stone-50 px-3 py-2 text-sm font-medium text-stone-900 outline-offset-2 transition hover:bg-stone-100 active:bg-stone-100 active:text-stone-900/60 active:transition-none dark:bg-stone-800/50 dark:text-stone-300 dark:hover:bg-stone-800 dark:hover:text-stone-50 dark:active:bg-stone-800/50 dark:active:text-stone-50/70"
+    class="group mt-6 inline-flex w-full items-center justify-center gap-2 rounded-md bg-stone-50 px-3 py-2 text-sm font-medium text-accent-900 outline-offset-2 transition hover:bg-stone-100 active:bg-stone-100 active:text-accent-900/60 active:transition-none dark:bg-stone-800/50 dark:text-accent-300 dark:hover:bg-stone-800 dark:hover:text-accent-50 dark:active:bg-stone-800/50 dark:active:text-accent-50/70"
     href="#"
   >A Call To Action??
     <img

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -8,7 +8,7 @@
     role="form"
     action="https://pro.dbflex.net/secure/gateway.aspx?action=WebToRecord&amp;app=15331&amp;table=1510483"
   >
-    <h2 class="flex text-sm font-semibold text-stone-900 dark:text-stone-100">
+    <h2 class="flex text-sm font-semibold text-accent-900 dark:text-accent-100">
       <img
         alt=""
         loading="lazy"
@@ -19,7 +19,7 @@
       >
       <span class="ml-3">{{ i18n.newsletter.title }}</span>
     </h2>
-    <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">
+    <p class="mt-2 text-sm text-accent-600 dark:text-accent-400">
       {{ i18n.newsletter.description }}
     </p>
     <div class="mt-6 flex">
@@ -34,13 +34,13 @@
         placeholder="{{ i18n.newsletter.placeholder }}"
         aria-label="{{ i18n.newsletter.placeholder }}"
         required
-        class="min-w-0 flex-auto appearance-none rounded-md border border-stone-900/10 bg-white px-3 py-[calc(--spacing(2)-1px)] shadow-md shadow-stone-800/5 placeholder:text-stone-400 focus:border-sky-500 focus:ring-4 focus:ring-sky-500/10 focus:outline-hidden sm:text-sm dark:border-stone-700 dark:bg-stone-700/[0.15] dark:text-stone-200 dark:placeholder:text-stone-500 dark:focus:border-sky-400 dark:focus:ring-sky-400/10 invalid:[&:not(:placeholder-shown):not(:focus)]:border-red-500 peer"
+        class="min-w-0 flex-auto appearance-none rounded-md border border-stone-900/10 bg-white px-3 py-[calc(--spacing(2)-1px)] shadow-md shadow-stone-800/5 placeholder:text-accent-400 focus:border-sky-500 focus:ring-4 focus:ring-sky-500/10 focus:outline-hidden sm:text-sm dark:border-stone-700 dark:bg-stone-700/[0.15] dark:text-accent-200 dark:placeholder:text-accent-500 dark:focus:border-sky-400 dark:focus:ring-sky-400/10 invalid:[&:not(:placeholder-shown):not(:focus)]:border-red-500 peer"
       />
       <span class="mt-2 hidden text-sm text-red-500 peer-[&:not(:placeholder-shown):not(:focus):invalid]:block">
             X
       </span>
       <button
-        class="ml-4 inline-flex flex-none items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold outline-offset-2 text-stone-50 bg-sky-500 transition hover:bg-sky-400 active:bg-sky-600 active:text-sky-100/70 active:transition-none dark:bg-sky-700 dark:hover:bg-sky-600 dark:active:bg-sky-700 dark:active:text-sky-100/70 transform hover:scale-105 active:scale-100 focus:ring-4 focus:ring-sky-500/50 group-invalid:pointer-events-none group-invalid:opacity-50"
+        class="ml-4 inline-flex flex-none items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold outline-offset-2 text-accent-50 bg-sky-500 transition hover:bg-sky-400 active:bg-sky-600 active:text-sky-100/70 active:transition-none dark:bg-sky-700 dark:hover:bg-sky-600 dark:active:bg-sky-700 dark:active:text-sky-100/70 transform hover:scale-105 active:scale-100 focus:ring-4 focus:ring-sky-500/50 group-invalid:pointer-events-none group-invalid:opacity-50"
         type="submit"
       >
         {{ i18n.newsletter.button }}
@@ -48,7 +48,7 @@
     </div>
   </form>
   <div class="rounded-2xl border border-stone-100 p-6 dark:border-stone-700/40 mt-6 lg:mt-0">
-    <h2 class="flex text-sm font-semibold text-stone-900 dark:text-stone-100">
+    <h2 class="flex text-sm font-semibold text-accent-900 dark:text-accent-100">
       <img
       alt=""
       loading="lazy"
@@ -59,11 +59,11 @@
     >
       <span class="ml-3">{{ i18n.contact.title}}</span>
     </h2>
-    <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">
+    <p class="mt-2 text-sm text-accent-600 dark:text-accent-400">
       {{ i18n.contact.description }}
     </p>
     <div class="mt-6 flex justify-center">
-      <a href="{{ i18n.contact.url }}" target="_blank" rel="noopener" role="button" tabindex="0" aria-label="{{ i18n.contact.aria_label }}" class="inline-flex flex-none items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold  outline-offset-2 text-stone-50 bg-sky-500 transition hover:bg-sky-400 active:bg-sky-600 active:text-sky-100/70 active:transition-none dark:bg-sky-700 dark:hover:bg-sky-600 dark:active:bg-sky-700 dark:active:text-sky-100/70 transform hover:scale-105 active:scale-100 focus:ring-4 focus:ring-sky-500/50">
+      <a href="{{ i18n.contact.url }}" target="_blank" rel="noopener" role="button" tabindex="0" aria-label="{{ i18n.contact.aria_label }}" class="inline-flex flex-none items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold  outline-offset-2 text-accent-50 bg-sky-500 transition hover:bg-sky-400 active:bg-sky-600 active:text-sky-100/70 active:transition-none dark:bg-sky-700 dark:hover:bg-sky-600 dark:active:bg-sky-700 dark:active:text-sky-100/70 transform hover:scale-105 active:scale-100 focus:ring-4 focus:ring-sky-500/50">
         {{ i18n.contact.button }}
       </a>
     </div>

--- a/src/_includes/templates/post-details.vto
+++ b/src/_includes/templates/post-details.vto
@@ -3,7 +3,7 @@
   {{ if date !== "hide" }}
     <time
       datetime="{{ date }}"
-      class="order-first flex items-center text-stone-400 dark:text-stone-300"
+      class="order-first flex items-center text-accent-400 dark:text-accent-300"
     >
       <span class="h-4 w-0.5 rounded-full bg-stone-200 dark:bg-stone-400"></span>
       <span class="ml-3">{{ date |> date("DATE") }}</span>
@@ -24,21 +24,21 @@
     {{ set page = search.page(`type=author lang=${lang} author="${author}"`) }}
     {{ if page }}
       <span
-        class="relative px-2 py-1 text-xs font-light text-stone-400 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-700"
+        class="relative px-2 py-1 text-xs font-light text-accent-400 dark:text-accent-300 hover:bg-stone-50 dark:hover:bg-stone-700"
       >{{ i18n.post.by }}: <a
-          class="no-underline text-stone-400 dark:text-stone-300"
+          class="no-underline text-accent-400 dark:text-accent-300"
           data-pagefind-filter="{{ i18n.search.filter_by_author }}"
           href="{{ page.url }}"
         >{{ author }}</a></span>
     {{ else }}
-      <span class="relative px-2 py-1 text-xs font-light text-stone-400 dark:text-stone-300">{{
+      <span class="relative px-2 py-1 text-xs font-light text-accent-400 dark:text-accent-300">{{
           i18n.post.by
         }}
         {{ author }}</span>
     {{ /if }}
   {{ /if }}
   {{ if readingInfo !== "hide" }}
-  <span class="relative px-2 py-1 text-xs font-light text-stone-400 dark:text-stone-300">{{
+  <span class="relative px-2 py-1 text-xs font-light text-accent-400 dark:text-accent-300">{{
       i18n.post.reading_time
     }}: <span class="font-medium">{{ it.readingInfo.minutes }}{{
         if lang === "en"
@@ -50,13 +50,13 @@
       {{ i18n.post.hot }}
     </span>{{ /if }}
 </div>
-<div class="text-xs/3 text-stone-500 ml-4 mt-2 flex space-x-2 break-keep">
+<div class="text-xs/3 text-accent-500 ml-4 mt-2 flex space-x-2 break-keep">
   {{ for tag of tags }}
     {{ set page = search.page(`type=tag lang=${lang} tag="${tag}"`) }}
     {{ if page }}
       <a
         data-pagefind-filter="{{ i18n.search.filter_by_tag }}"
-        class="relative rounded-md bg-stone-50 px-2 py-1 text-xs font-medium text-stone-600 ring-1 ring-stone-500/10 ring-inset hover:bg-stone-100 no-underline"
+        class="relative rounded-md bg-stone-50 px-2 py-1 text-xs font-medium text-accent-600 ring-1 ring-stone-500/10 ring-inset hover:bg-stone-100 no-underline"
         href="{{ page.url }}"
       >{{ tag }}</a>
     {{ /if }}

--- a/src/_includes/templates/post-list.vto
+++ b/src/_includes/templates/post-list.vto
@@ -3,7 +3,7 @@
   <article class="md:grid md:grid-cols-4 md:items-baseline">
     <div class="group relative flex flex-col items-start md:col-span-3">
       <h2
-        class="text-base font-semibold tracking-tight text-stone-800 dark:text-stone-100"
+        class="text-base font-semibold tracking-tight text-accent-800 dark:text-accent-100"
       >
         <div
           class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-stone-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-stone-800/50"
@@ -28,7 +28,7 @@
         </a>
       </h2>
       <time
-        class="relative z-10 order-first mb-3 flex items-center pl-3.5 text-sm text-stone-400 md:hidden dark:text-stone-500"
+        class="relative z-10 order-first mb-3 flex items-center pl-3.5 text-sm text-accent-400 md:hidden dark:text-accent-500"
         datetime="{{ post.date }}"
       ><span
           class="absolute inset-y-0 left-0 flex items-center"
@@ -37,7 +37,7 @@
             class="h-4 w-0.5 rounded-full bg-stone-200 dark:bg-stone-500"
           ></span></span>{{ post.date |> date("DATE") }}</time>
       <div
-        class="relative z-10 mt-2 text-sm/7 text-stone-600 dark:text-stone-200 truncate w-full"
+        class="relative z-10 mt-2 text-sm/7 text-accent-600 dark:text-accent-200 truncate w-full"
       >
         {{ post.excerpt |> md(true) }}
       </div>
@@ -65,7 +65,7 @@
       </div>
     </div>
     <time
-      class="relative z-10 order-first mt-1 mb-3 flex items-center text-sm text-stone-400 max-md:hidden dark:text-stone-500"
+      class="relative z-10 order-first mt-1 mb-3 flex items-center text-sm text-accent-400 max-md:hidden dark:text-accent-500"
       datetime="{{ post.date }}"
     >{{ post.date |> date("DATE") }}{{ if post.elapseddays < 40 }}<img
           class="size-6 fill-sky-400"

--- a/src/_includes/templates/post-list.vto
+++ b/src/_includes/templates/post-list.vto
@@ -3,7 +3,7 @@
   <article class="md:grid md:grid-cols-4 md:items-baseline">
     <div class="group relative flex flex-col items-start md:col-span-3">
       <h2
-        class="text-base font-semibold tracking-tight text-accent-800 dark:text-accent-100"
+        class="text-base font-semibold tracking-tight text-accent-900 dark:text-accent-100"
       >
         <div
           class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-stone-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-stone-800/50"

--- a/src/_includes/templates/slider1.vto
+++ b/src/_includes/templates/slider1.vto
@@ -34,7 +34,7 @@
                   aria-current="page"{{ /if }}
               >
                 <div
-                  class="absolute top-1/4 left-1/2 transform -translate-x-1/2 text-stone-50 bg-{{ if catColor }}{{ catColor }}-500/40{{ else }}white/60{{ /if }} transition delay-150 duration-300 ease-in-out hover:bg-{{ if catColor }}{{ catColor }}-600/40{{ else }}white/40{{ /if }} hover:scale-102 hover:grayscale hover:invert dark:hover:invert-0 p-5 rounded-lg w-2/3"
+                  class="absolute top-1/4 left-1/2 transform -translate-x-1/2 text-accent-50 bg-{{ if catColor }}{{ catColor }}-500/40{{ else }}white/60{{ /if }} transition delay-150 duration-300 ease-in-out hover:bg-{{ if catColor }}{{ catColor }}-600/40{{ else }}white/40{{ /if }} hover:scale-102 hover:grayscale hover:invert dark:hover:invert-0 p-5 rounded-lg w-2/3"
                 >
                   <h2 class="text-3xl mb-4">{{ post.title }}</h2>
                   <p class="text-sm">{{ post.excerpt |> md(true) }}</p>

--- a/src/_includes/templates/top-certs.vto
+++ b/src/_includes/templates/top-certs.vto
@@ -3,10 +3,10 @@
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl pt-8 pb-8">  
     <div class="grid grid-cols-1 gap-12 items-center lg:grid-cols-4 md:grid-cols-2"> 
       <div class="col-span-full lg:col-span-1 lg:max-w-none lg:mr-auto mx-auto"> 
-        <h2 id="certifications" class="prose prose-zinc font-semibold text-sm text-balance">  
+        <h2 id="certifications" class="prose prose-neutral font-semibold text-sm text-balance">  
           <a class="text-yellow-500 hover:text-sky-500 no-underline" href="#certifications">{{ certifications.title }}</a>
         </h2> 
-        <p class="prose prose-zinc text-sm text-balance">
+        <p class="prose prose-neutral text-accent-950 text-sm text-balance">
           {{ certifications.copy }}
         </p> 
       </div> 

--- a/src/_includes/templates/top-hero-text-ticker-image.vto
+++ b/src/_includes/templates/top-hero-text-ticker-image.vto
@@ -3,7 +3,7 @@
   <div class="2xl:max-w-7xl mx-auto px-8 pb-0 py-12 lg:pt-24">  
     <div class="grid items-end gap-4 lg:grid-cols-4 max-w-5xl mx-auto"> 
       <div class="lg:col-span-2"> 
-        <h1 class="text-4xl sm:text-4xl md:text-5xl lg:text-6xl tracking-tighter font-display text-accent-800 text-balance">  
+        <h1 class="text-4xl sm:text-4xl md:text-5xl lg:text-6xl tracking-tighter font-display text-accent-900 text-balance">  
         {{ hero.title }}
         </h1>
       </div> 

--- a/src/_includes/templates/top-hero-text.vto
+++ b/src/_includes/templates/top-hero-text.vto
@@ -7,7 +7,7 @@
         {{ hero.title }}
         </h1>
       </div> 
-      <p class="prose prose-zinc prose-base prose-p:text-accent-900 lg:col-span-2 text-pretty lg:-mt-2">  
+      <p class="prose prose-neutral prose-base prose-p:text-accent-950 lg:col-span-2 text-pretty lg:-mt-2">  
       {{ hero.copy }}
       </p> 
     </div>  

--- a/src/_includes/templates/top-main-cats1.vto
+++ b/src/_includes/templates/top-main-cats1.vto
@@ -5,7 +5,7 @@
     set pageCats = search.pages(`type=category lang=${lang}`, "category=desc-locale")
   }}
   {{ if pageCats.length }}
-    <div class="text-stone-500 ml-1 mt-2">
+    <div class="text-accent-500 ml-1 mt-2">
       <nav class="">
         <ul class="flex flex-wrap space-x-2 space-y-2">
           {{ for page of pageCats }}

--- a/src/_includes/templates/top-nav1.vto
+++ b/src/_includes/templates/top-nav1.vto
@@ -56,7 +56,7 @@
                 <div class="pointer-events-auto md:hidden relative">
                   <button
                     aria-label="Toggle menu"
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-stone-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-stone-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-accent-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     x-data
                     @click="$dispatch('toggle-menu')"
@@ -92,7 +92,7 @@
                     {{- for item of it.topnav.links }}
                       <li>
                         <a
-                          class="group relative block whitespace-nowrap px-3 py-2 transition text-stone-50 dark:text-stone-200 hover:text-sky-400 dark:hover:text-sky-500 {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
+                          class="group relative block whitespace-nowrap px-3 py-2 transition text-accent-50 dark:text-accent-200 hover:text-sky-400 dark:hover:text-sky-500 {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
                           href="{{ item.href }}"
                           {{- if item.target }}target="{{ item.target }}"{{ /if -}}
                           {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
@@ -156,11 +156,11 @@
                     <button
                       type="button"
                       aria-label="Toggle language"
-                      class="group rounded-full bg-esoliaamber-500/90 px-3 py-2 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm transition dark:bg-stone-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium dark:group-hover:text-stone-100"
+                      class="group rounded-full bg-esoliaamber-500/90 px-3 py-2 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm transition dark:bg-stone-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium dark:group-hover:text-accent-100"
                     >
                       {{- for alt of alternates }}{{ if alt.lang !== lang }}
                           <a
-                            class="group text-stone-50 dark:text-stone-200 hover:text-sky-400 dark:hover:text-sky-500"
+                            class="group text-accent-50 dark:text-accent-200 hover:text-sky-400 dark:hover:text-sky-500"
                             href="{{ alt.url }}"
                             title="{{ alt.title |> escape }}"
                           >
@@ -190,7 +190,7 @@
                     </span>
                   </button>
                   <div
-                    class="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 px-2 py-1 bg-stone-200 text-stone-900 dark:bg-stone-700 dark:text-stone-200  text-sm rounded-md opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-300 pointer-events-none z-50 whitespace-nowrap before:content-[''] before:absolute before:bottom-full before:left-1/2 before:transform before:-translate-x-1/2 before:border-8 before:border-x-transparent before:border-t-0 before:border-b-stone-200 dark:before:border-b-stone-700"
+                    class="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 px-2 py-1 bg-stone-200 text-accent-900 dark:bg-stone-700 dark:text-accent-200  text-sm rounded-md opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-300 pointer-events-none z-50 whitespace-nowrap before:content-[''] before:absolute before:bottom-full before:left-1/2 before:transform before:-translate-x-1/2 before:border-8 before:border-x-transparent before:border-t-0 before:border-b-stone-200 dark:before:border-b-stone-700"
                   >
                     {{ i18n.search.tooltip }}
                   </div>

--- a/src/_includes/templates/top-nav1.vto
+++ b/src/_includes/templates/top-nav1.vto
@@ -56,7 +56,7 @@
                 <div class="pointer-events-auto md:hidden relative">
                   <button
                     aria-label="Toggle menu"
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-accent-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-accent-900 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     x-data
                     @click="$dispatch('toggle-menu')"

--- a/src/_includes/templates/top-nav3.vto
+++ b/src/_includes/templates/top-nav3.vto
@@ -79,7 +79,7 @@
                   data-headlessui-state=""
                 >
                   <button
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-accent-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-accent-900 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     aria-expanded="false"
                     data-headlessui-state=""
@@ -107,7 +107,7 @@
                 </div>
                 <nav class="pointer-events-auto hidden md:block">
                   <ul
-                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-accent-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10"
+                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-accent-900 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10"
                   >
                     <li>
                       <a

--- a/src/_includes/templates/top-nav3.vto
+++ b/src/_includes/templates/top-nav3.vto
@@ -79,7 +79,7 @@
                   data-headlessui-state=""
                 >
                   <button
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-stone-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-stone-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-accent-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     aria-expanded="false"
                     data-headlessui-state=""
@@ -107,7 +107,7 @@
                 </div>
                 <nav class="pointer-events-auto hidden md:block">
                   <ul
-                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-stone-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-stone-200 dark:ring-white/10"
+                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-accent-800 ring-1 shadow-lg shadow-stone-800/5 ring-stone-900/5 backdrop-blur-sm dark:bg-stone-800/90 dark:text-accent-200 dark:ring-white/10"
                   >
                     <li>
                       <a

--- a/src/_includes/templates/top-partners.vto
+++ b/src/_includes/templates/top-partners.vto
@@ -3,10 +3,10 @@
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl py-12">  
     <div class="grid grid-cols-1 gap-12 items-center lg:grid-cols-4 md:grid-cols-2"> 
       <div class="col-span-full lg:col-span-1 lg:max-w-none lg:mr-auto mx-auto"> 
-        <h2 id="partners" class="prose prose-zinc font-semibold text-sm text-balance">  
+        <h2 id="partners" class="prose prose-neutral font-semibold text-sm text-balance">  
           <a class="text-yellow-500 hover:text-sky-500 no-underline" href="#partners">{{ partners.title }}</a>
         </h2> 
-        <p class="prose prose-zinc text-sm text-balance">
+        <p class="prose prose-neutral text-accent-950 text-sm text-balance">
           {{ partners.copy }}
         </p>
       </div> 

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -61,7 +61,7 @@
             <a
               href="{{ post.url }}"
               data-faid="{{ post.lang }}-{{ if post.id.length > 0 }}{{ post.id }}{{ else }}{{ loop.index }}{{ /if }}"
-              class="data-fatrigger text-accent-800 hover:text-sky-500 dark:text-accent-50 dark:hover:text-sky-500"
+              class="data-fatrigger text-accent-900 hover:text-sky-500 dark:text-accent-50 dark:hover:text-sky-500"
               {{ if post.url == url }}
                 aria-current="page"{{ /if }}
             >

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -61,7 +61,7 @@
             <a
               href="{{ post.url }}"
               data-faid="{{ post.lang }}-{{ if post.id.length > 0 }}{{ post.id }}{{ else }}{{ loop.index }}{{ /if }}"
-              class="data-fatrigger text-stone-800 hover:text-sky-500 dark:text-stone-50 dark:hover:text-sky-500"
+              class="data-fatrigger text-accent-800 hover:text-sky-500 dark:text-accent-50 dark:hover:text-sky-500"
               {{ if post.url == url }}
                 aria-current="page"{{ /if }}
             >
@@ -72,7 +72,7 @@
                 </span>{{ /if }} #}}
             </a>
           </h3>
-          <p class="mt-5 line-clamp-3 text-sm/6 text-stone-600 dark:text-stone-300">
+          <p class="mt-5 line-clamp-3 text-sm/6 text-accent-600 dark:text-accent-300">
             {{ post.excerpt |> md(true) }}
           </p>
         </div>

--- a/src/_includes/templates/top-post-list.vto
+++ b/src/_includes/templates/top-post-list.vto
@@ -13,7 +13,7 @@
       }}
     </div>
     <h2
-      class="text-base font-semibold tracking-tight text-stone-800 dark:text-stone-100"
+      class="text-base font-semibold tracking-tight text-accent-800 dark:text-accent-100"
     >
       <div
         class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-stone-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-stone-800/50"
@@ -36,7 +36,7 @@
             </span>{{ /if }}
         </span></a>
     </h2>
-    <p class="relative z-10 mt-2 text-sm text-stone-600 dark:text-stone-400">
+    <p class="relative z-10 mt-2 text-sm text-accent-600 dark:text-accent-400">
       {{ post.excerpt |> md(true) }}
     </p>
     <div

--- a/src/_includes/templates/top-post-list.vto
+++ b/src/_includes/templates/top-post-list.vto
@@ -13,7 +13,7 @@
       }}
     </div>
     <h2
-      class="text-base font-semibold tracking-tight text-accent-800 dark:text-accent-100"
+      class="text-base font-semibold tracking-tight text-accent-900 dark:text-accent-100"
     >
       <div
         class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-stone-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-stone-800/50"

--- a/src/_includes/templates/top-projects.vto
+++ b/src/_includes/templates/top-projects.vto
@@ -14,44 +14,24 @@
   // Define gradient class combinations including dark mode.
     const gradientOptions = [
     {
-      // All sky gradient
-      light: 'bg-gradient-to-tr from-sky-800 via-sky-600 to-sky-700',
-      dark: 'dark:bg-gradient-to-br dark:from-sky-900 dark:via-sky-700 dark:to-sky-600' 
+      // accent gray gradient 1
+      light: 'bg-gradient-to-br from-accent-200 to-accent-50',
+      dark: 'dark:bg-gradient-to-br dark:from-accent-900 dark:to-accent-700'
     },
     {
-      // All Sky gradient
-      light: 'bg-gradient-to-br from-sky-900 via-sky-600 to-sky-500',
-      dark: 'dark:bg-gradient-to-br dark:from-sky-900 dark:via-sky-700 dark:to-sky-600' 
+      // accent gray gradient 2
+      light: 'bg-gradient-to-br from-accent-200 to-accent-50',
+      dark: 'dark:bg-gradient-to-br dark:from-accent-900 dark:to-accent-700'
     },
     {
-      // All sky gradient
-      light: 'bg-gradient-to-tl from-sky-800 via-sky-600 to-sky-700',
-      dark: 'dark:bg-gradient-to-br dark:from-sky-900 dark:via-sky-700 dark:to-sky-600' 
+      // accent gray gradient 3
+      light: 'bg-gradient-to-bl from-accent-50 to-accent-100',
+      dark: 'dark:bg-gradient-to-tr dark:from-accent-900 dark:to-accent-700'
     },
     {
-      // All Sky gradient
-      light: 'bg-gradient-to-bl from-sky-900 via-sky-600 to-sky-500',
-      dark: 'dark:bg-gradient-to-br dark:from-sky-900 dark:via-sky-700 dark:to-sky-600' 
-    },
-    {
-      // Sky-cyan gradient
-      light: 'bg-gradient-to-br from-sky-700 to-cyan-500',
-      dark: 'dark:bg-gradient-to-br dark:from-sky-900 dark:to-cyan-700' 
-    },
-    {
-      // Sky-cyan gradient
-      light: 'bg-gradient-to-bl from-sky-700 via-sky-800 to-cyan-500',
-      dark: 'dark:bg-gradient-to-br dark:from-sky-900 via-sky-950 dark:to-cyan-700' 
-    },
-    {
-      // Teal-cyan-sky gradient
-      light: 'bg-gradient-to-br from-teal-700 via-cyan-500 to-sky-600',
-      dark: 'dark:bg-gradient-to-br dark:from-teal-900 via-cyan-800 dark:to-sky-700' 
-    },
-    {
-      // Sky-teal gradient
-      light: 'bg-gradient-to-br from-sky-700 to-teal-500',
-      dark: 'dark:bg-gradient-to-br dark:from-sky-900 dark:to-teal-700' 
+      // accent gray gradient 4
+      light: 'bg-gradient-to-bl from-accent-100 to-accent-50',
+      dark: 'dark:bg-gradient-to-br dark:from-accent-900 dark:to-accent-700'
     }
     // Add more objects if needed
     ];
@@ -65,18 +45,18 @@
     }}
     <article class="relative isolate flex flex-col overflow-hidden rounded-2xl
     {{ selectedGradient.light }} {{ selectedGradient.dark }} 
-    grayscale opacity-90 shadow-md px-8 pt-8 pb-8 sm:pt-10 lg:pt-12">
-      <div class="absolute inset-0 -z-10 rounded-2xl bg-accent-100 blur opacity-50"></div>
-      <div class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-accent-900/10 ring-inset blur opacity-25"></div>
+    shadow-md px-8 pt-8 pb-8 sm:pt-10 lg:pt-12 backdrop-blur-sm">
+      {{# <div class="absolute inset-0 -z-10 rounded-2xl bg-accent-100 blur opacity-50"></div> #}}
+      {{# <div class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-accent-900/10 ring-inset opacity-40"></div> #}}
       <div class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6">
-        <time datetime="{{ project['DateYYYY-MM-DD'] }}" class="mr-8 text-accent-700">{{ if lang === "ja" }}{{ project['DateJP'] }}{{ else }}{{ project['Date'] }}{{ /if }}</time>
+        <time datetime="{{ project['DateYYYY-MM-DD'] }}" class="mr-8 text-accent-950">{{ if lang === "ja" }}{{ project['DateJP'] }}{{ else }}{{ project['Date'] }}{{ /if }}</time>
         </div>
-        <h3 class="mt-3 text-lg/6 font-semibold text-white">
+        <h3 class="mt-3 text-lg/6 font-semibold text-accent-950">
             <span class="absolute inset-0"></span>
             {{ if lang === "ja" }}{{ project['顧客タイプ'] }}{{ else }}{{ project['Client Type'] }}{{ /if }}
         </h3>
-        <div class="text-white mt-5 text-sm/6 leading-6">
-          {{ if lang === "ja" }}{{ project['記事'] |> md(true) }}{{ else }}{{ project['Description'] |> md(true) }}{{ /if }}
+        <div class="prose prose-neutral prose-sm text-accent-950 mt-5 text-sm/6 leading-6">
+          {{ if lang === "ja" }}{{ project['記事'] |> md }}{{ else }}{{ project['Description'] |> md }}{{ /if }}
         </div>
       </article>
     {{ /for }}

--- a/src/_includes/templates/top-services.vto
+++ b/src/_includes/templates/top-services.vto
@@ -9,7 +9,7 @@
     <div class="flex flex-col flex-shrink-0 gap-8 md:flex-row md:gap-12 mt-12 md:items-center no-external-icon"> 
       <ul role="list" class="list-disc marker:text-sky-400 flex flex-col gap-y-2 max-w-xl w-full ml-4"> 
         {{ for service of services.list |> shuffle }}
-        <li class="prose prose-zinc prose-base prose-li:text-accent-700"> {{ service.name }} </li>
+        <li class="prose prose-neutral prose-base prose-li:text-accent-700"> {{ service.name }} </li>
         {{ /for }}
       </ul> 
       <a 

--- a/src/_includes/templates/top-testimonials.vto
+++ b/src/_includes/templates/top-testimonials.vto
@@ -12,15 +12,15 @@
   <div class="2xl:max-w-7xl mx-auto px-4 sm:px-6 md:px-16 max-w-6xl pb-16">  
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
       {{ for testimonial of testimonials.list |> shuffle }}
-      <div class="flex flex-col pb-10 sm:pb-16 lg:pr-8 lg:pb-0 xl:pr-20 rounded-2xl bg-{{ testimonial.color }}-50 p-6 shadow-lg ring-1 ring-accent-900/5">
+      <div class="flex flex-col pb-2 sm:pb-8 lg:pr-8 lg:pb-0 xl:pr-20 rounded-2xl bg-{{ testimonial.color }}-50 p-6 shadow-lg ring-1 ring-accent-900/5">
         <img
           class="size-24 fill-{{ testimonial.color }}-600"
           src='{{ "quotes" |> icon("phosphor", "duotone") }}'
           inline>
 
         <aside class="flex flex-auto flex-col justify-between">
-          <blockquote class="prose prose-zinc text-accent-950 font-thin text-xl sm:text-2xl md:text-3xl text-pretty">
-            <p class="pb-8">{{ testimonial.quote }}</p>
+          <blockquote class="prose prose-neutral text-accent-950 font-thin text-lg sm:text-xl md:text-2xl text-pretty">
+            <p class="pb-4 lg:pb-8">{{ testimonial.quote }}</p>
           </blockquote>
         </aside>
       </div>

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -5,13 +5,13 @@
       <div class="mx-auto max-w-2xl lg:max-w-5xl">
         <div class="max-w-2xl">
           <h1
-            class="text-4xl tracking-tight text-accent-800 sm:text-5xl dark:text-accent-100"
+            class="text-4xl tracking-tight text-accent-900 sm:text-5xl dark:text-accent-100"
           >
             {{# <span class="font-light">{{ i18n.home.company }}</span>
             <br class="block sm:hidden"> #}}
             <span class="font-light subpixel-antialiased">{{ site.title }}</span>
           </h1>
-          <p class="mt-6 text-base text-accent-800 dark:text-accent-400">
+          <p class="mt-6 text-base text-accent-900 dark:text-accent-400">
             {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
           </p>
           <div class="mt-6 flex gap-6 no-external-icon">

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -5,13 +5,13 @@
       <div class="mx-auto max-w-2xl lg:max-w-5xl">
         <div class="max-w-2xl">
           <h1
-            class="text-4xl tracking-tight text-stone-800 sm:text-5xl dark:text-stone-100"
+            class="text-4xl tracking-tight text-accent-800 sm:text-5xl dark:text-accent-100"
           >
             {{# <span class="font-light">{{ i18n.home.company }}</span>
             <br class="block sm:hidden"> #}}
             <span class="font-light subpixel-antialiased">{{ site.title }}</span>
           </h1>
-          <p class="mt-6 text-base text-stone-800 dark:text-stone-400">
+          <p class="mt-6 text-base text-accent-800 dark:text-accent-400">
             {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
           </p>
           <div class="mt-6 flex gap-6 no-external-icon">

--- a/src/_includes/templates/top-welcome-header1.vto
+++ b/src/_includes/templates/top-welcome-header1.vto
@@ -1,5 +1,5 @@
 <!-- ===== top-welcome-header1.vto TEMPLATE START ===== -->
-<section class="bg-white overflow-hidden relative"> <div class="2xl:max-w-7xl mx-auto  px-8 pb-0 py-12 lg:pt-24">  <div class="grid items-end gap-4 lg:grid-cols-3 max-w-5xl mx-auto"> <div class="lg:col-span-2"> <h1 class="text-4xl  sm:text-4xl md:text-5xl lg:text-6xl tracking-tighter font-display text-accent-800 text-balance">  
+<section class="bg-white overflow-hidden relative"> <div class="2xl:max-w-7xl mx-auto  px-8 pb-0 py-12 lg:pt-24">  <div class="grid items-end gap-4 lg:grid-cols-3 max-w-5xl mx-auto"> <div class="lg:col-span-2"> <h1 class="text-4xl  sm:text-4xl md:text-5xl lg:text-6xl tracking-tighter font-display text-accent-900 text-balance">  
 Your virtual IT department in Japan
   </h1> </div> <p class="text-base font-medium text-accent-500">  
 We are a team of creatives and developers who work together to create a

--- a/src/_includes/templates/top-why.vto
+++ b/src/_includes/templates/top-why.vto
@@ -30,7 +30,7 @@
               inline>
             {{ reason.name }}
           </dt> 
-          <dd class="prose prose-zinc text-accent-50 text-base mt-4 text-pretty"> 
+          <dd class="prose prose-neutral text-accent-50 text-base mt-4 text-pretty"> 
             {{ reason.description }} 
           </dd> 
         </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,3 +1,20 @@
+// Load this first
+(function() {
+    var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+
+    if (/windows phone/i.test(userAgent)) {
+        document.body.classList.add('os-windows-phone');
+    } else if (/android/i.test(userAgent)) {
+        document.body.classList.add('os-android');
+    } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+        document.body.classList.add('os-ios');
+    } else if (/Mac/i.test(userAgent)) {
+        document.body.classList.add('os-mac');
+    } else if (/Win/i.test(userAgent)) { // This would catch most Windows desktops/laptops
+        document.body.classList.add('os-windows');
+    }
+})();
+
 // Function to load a script from a CDN with additional attributes
 function loadVendorScript(src, attributes, callback) {
   var script = document.createElement('script');
@@ -218,4 +235,29 @@ document.addEventListener('DOMContentLoaded', function() {
 
 }); // End DOMContentLoaded listener
 
+// For TOC details opening
+// This script will automatically open the Table of Contents (ToC) on medium and larger screens
+document.addEventListener('DOMContentLoaded', () => {
+    const tocDetails = document.getElementById('toc-details');
+    if (!tocDetails) {
+        console.warn('Table of Contents details element not found!');
+        return;
+    }
+    const handleDetailsState = () => {
+        const isMediumOrLargeScreen = window.matchMedia('(min-width: 768px)').matches;
 
+        if (isMediumOrLargeScreen) {
+            // On medium and larger screens:
+            // The 'open' attribute is set in the HTML. We DO NOT modify it here.
+            // This allows the user to freely open/close the ToC, and their action will persist.
+        } else {
+            // On smaller screens:
+            // Ensure the ToC is always closed by default (remove 'open' if present).
+            tocDetails.removeAttribute('open');
+        }
+    };
+    // Set initial state on page load
+    handleDetailsState();
+    // Re-evaluate state on window resize
+    window.addEventListener('resize', handleDetailsState);
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -281,6 +281,19 @@ body article > div > p:first-of-type {
   @apply text-base text-lg lg:text-xl font-light leading-relaxed text-accent-950 dark:text-accent-200;
 }
 
+/* Target project cards p */
+/* This targets the <p> inside the .prose block within each article */
+section.bg-white article .prose > p {
+  @apply text-sm font-normal leading-5 text-accent-950 dark:text-accent-200;
+}
+/* Target leading in card lists */
+section.bg-white article .prose > ol {
+  @apply leading-5;
+}
+section.bg-white article .prose > ul {
+  @apply leading-5;
+}
+
 /* Specific styles for Windows devices */
 /* More specific due to `body.os-windows`; overrides default */
 body.os-windows article > div > p:first-of-type {

--- a/src/styles.css
+++ b/src/styles.css
@@ -305,9 +305,13 @@ body.os-windows article > div > p:first-of-type {
   /* font-medium (font-weight: 500) */
   /* @apply font-medium; */
 }
-
+/* Make toc text heavier */
 body.os-windows header > nav {
   @apply prose-a:font-normal;
+}
+/* Make blockquote text heavier  */
+body.os-windows aside > blockquote.prose {
+  @apply font-normal;
 }
 
 body article > div > figure > picture > img {

--- a/src/styles.css
+++ b/src/styles.css
@@ -275,8 +275,26 @@
   @apply text-lg font-light leading-relaxed;
 }
 
+/* Default lede paragraph styles (Mac, Linux, etc.) */
+/* font-weight: 300; */
 body article > div > p:first-of-type {
-  @apply text-base text-lg lg:text-xl font-light leading-relaxed text-stone-800 dark:text-stone-200;
+  @apply text-base text-lg lg:text-xl font-light leading-relaxed text-accent-950 dark:text-accent-200;
+}
+
+/* Specific styles for Windows devices */
+/* More specific due to `body.os-windows`; overrides default */
+body.os-windows article > div > p:first-of-type {
+  /* Only override the font-weight, and it will use others*/
+  /* This is a workaround for the blurriness issue on Windows */
+  /* font-normal (font-weight: 400) */
+  @apply font-normal;
+
+  /* font-medium (font-weight: 500) */
+  /* @apply font-medium; */
+}
+
+body.os-windows header > nav {
+  @apply prose-a:font-normal;
 }
 
 body article > div > figure > picture > img {
@@ -397,6 +415,22 @@ mark {
 /* Hamburger アニメーション後のメニューの状態 */
 .mobile-menu.is-active {
   transform: translateX(0);
+}
+
+/* TOC */
+/* Remove default padding some browsers apply to summary */
+summary {
+  padding: 0;
+}
+
+/* Optional: Adjust spacing between summary and content when open on small screens */
+details[open] > summary {
+  margin-bottom: 0.5rem; /* Or adjust as needed for your design */
+}
+
+/* Ensure the ul within details doesn't have unwanted top margin if prose changes its default */
+#toc-details ul {
+  margin-top: 0;
 }
 
 /* lume-google-fonts-here */

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,16 +10,16 @@
 
 @layer base {
   a {
-    @apply text-stone-500 dark:text-stone-100 hover:text-sky-600 dark:hover:text-sky-400; /* Example base link styles */
+    @apply text-accent-500 dark:text-accent-100 hover:text-sky-600 dark:hover:text-sky-400; /* Example base link styles */
     transition: color 0.15s ease-in-out;
     text-decoration-thickness: 1px; /* Set your desired default thickness here as well */
     text-decoration-color: theme('colors.zinc.500'); /* Match the text color */
   }
 
   /* You could also style specific link states globally */
-  a:focus {
+  /* a:focus {
     @apply outline-none ring-2 ring-sky-700/50 ring-offset-2;
-  }
+  } */
 }
 @layer components {
   /* Apply base styles to tables with not-prose */
@@ -28,7 +28,7 @@
   }
 
   table.not-prose thead {
-    @apply bg-stone-50 text-stone-700 dark:bg-stone-600 dark:text-stone-300 text-left;
+    @apply bg-stone-50 text-accent-700 dark:bg-stone-600 dark:text-accent-300 text-left;
   }
 
   table.not-prose th,
@@ -44,11 +44,11 @@
     @apply divide-y divide-stone-200 dark:divide-stone-700;
   }
   table.not-prose caption {
-    @apply caption-bottom text-left p-2 text-xs text-stone-400;
+    @apply caption-bottom text-left p-2 text-xs text-accent-400;
   }
     /* Override the prose <a> tag hover classes */
   .prose :where(a) {
-    @apply hover:opacity-60;
+    @apply hover:opacity-70;
   }
 
   .prose figure + p {
@@ -303,7 +303,7 @@ body article > div > figure > picture > img {
 
 /* MDN keyboard shortcut style for kbd tag */
 kbd {
-  @apply bg-stone-200 rounded border border-stone-400 shadow-md text-stone-800 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap
+  @apply bg-stone-200 rounded border border-stone-400 shadow-md text-accent-800 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap
 }
 
 /*----------------------------


### PR DESCRIPTION
Updates styling to use a more consistent color palette and improves readability:
- Introduces a neutral color palette for prose elements.
- Improves the table of contents presentation.
- Adjusts footer and text colors for better contrast and accessibility.
- Prevents HTML from leaking into the title.
- Sets navigation privacy links to internal paths.

b64946d7de79b6e24fa6142a665757a64384d8de
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 22 05:04:40 2025 +0900

### Update prose styles and text colors
Change prose-zinc to the selected neutral gray via prose-neutral.

Change any hardcoded zinc or stone to neutral.



539a16e8c084d38b20b101165c9c9b53a0981e4f
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 22 05:02:35 2025 +0900

### Style testimonials
Make padding more consistent, and make it tighter.

Blockquote using a light text, so make this normal for windows.



6ddc787648b2f59018e273040198f782698368fe
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 22 05:01:23 2025 +0900

### Style project section cards
Go for a subtle gray gradient and remove complexity.

Use prose for the card for the base styles, but then it has to be overridden for some details within, and you don't have access to those until it builds, because it is pulling from data.

Tailwind's prose-* utilities are part of the Typography plugin, which applies styles to nested elements like <p>, <ul>, etc. However, prose-p:text-sm is not a valid Tailwind class. Tailwind doesn't support targeting specific elements like prose-p with utility classes directly.

Also tried **:text-sm but that did not work either.



5d6c8ec757a003ba4b73c7d218352422fcdf7873
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 19:47:36 2025 +0900

### Consolidate colors
"Accent" is set to neutral, but there are a number of hard coded colors, stone, zinc, in the code. Swap everything supposed to be gray, to "accent" meaning neutral.



28cbf1ff179290e5aa5c7862aa5f50afcb68bfc2
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 19:45:58 2025 +0900

### Refactor TOC
Make TOC like the blog site one - better contrast generally and expandable on small screens, expanded on large.

Also allow for os-specific styling.



40bf27a5f63f27c0e433c61df6eb4a8079fda1fd
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 19:40:16 2025 +0900

### Set nav privacy links
Privacy pages are now local to this site, to change footer link to the local one instead of the remote one



274f4117a43d6292c1fd78550669560a7b51cc3e
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 19:39:38 2025 +0900

### Prevent html from leaking into title
If a <br> is used in a page or post's title, it will leak into the browser tab etc.

This prevents that by filtering the title with plaintext filter.


![JRC CleanShot Microsoft Edge 2025-05-22-051005JST@2x](https://github.com/user-attachments/assets/097b85f7-2712-4228-98d7-fe4d96884919)
![JRC CleanShot Microsoft Edge 2025-05-22-051119JST@2x](https://github.com/user-attachments/assets/41d9f6d3-e64b-4114-9229-283d3fbb1d39)


